### PR TITLE
improve versioning

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,5 +1,5 @@
 # Source: https://github.com/rebuy-de/golang-template
-# Version: 1.2.0
+# Version: 1.2.1-snapshot
 
 FROM golang:1.8-alpine
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,5 +1,5 @@
 # Source: https://github.com/rebuy-de/golang-template
-# Version: 1.1.1-snapshot
+# Version: 1.2.0
 
 FROM golang:1.8-alpine
 

--- a/example/golang.mk
+++ b/example/golang.mk
@@ -7,7 +7,7 @@
 
 NAME=$(notdir $(PACKAGE))
 
-BUILD_VERSION=$(shell git describe --always --dirty | tr '-' '.' )
+BUILD_VERSION=$(shell git describe --always --dirty --tags | tr '-' '.' )
 BUILD_DATE=$(shell date -Iseconds)
 BUILD_HASH=$(shell git rev-parse HEAD)
 BUILD_MACHINE=$(shell echo $$HOSTNAME)
@@ -48,9 +48,12 @@ cov:
 build: vendor
 	go build \
 		$(BUILD_FLAGS) \
-		-o $(NAME)-$(BUILD_VERSION)
-	ln -sf $(NAME)-$(BUILD_VERSION) $(NAME)
+		-o $(NAME)-$(BUILD_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH)
+	ln -sf $(NAME)-$(BUILD_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH) $(NAME)
 
+xc:
+	GOOS=linux GOARCH=amd64 make build
+	GOOS=darwin GOARCH=amd64 make build
 
 install: test
 	go install \

--- a/example/golang.mk
+++ b/example/golang.mk
@@ -1,5 +1,5 @@
 # Source: https://github.com/rebuy-de/golang-template
-# Version: 1.1.1-snapshot
+# Version: 1.2.0
 # Dependencies:
 # * Glide
 # * gocov (https://github.com/axw/gocov)

--- a/example/golang.mk
+++ b/example/golang.mk
@@ -1,5 +1,5 @@
 # Source: https://github.com/rebuy-de/golang-template
-# Version: 1.2.0
+# Version: 1.2.1-snapshot
 # Dependencies:
 # * Glide
 # * gocov (https://github.com/axw/gocov)


### PR DESCRIPTION
* improve versioning (using git tag, now)
* add cross compiling
* change output file name to make it more useful for GitHub releases (eg `kubernetes-deployment-v2.0.1-darwin-amd64`)