### PR TITLE
use lowercase logrus dependency

### DIFF
--- a/example/cmd/root.go
+++ b/example/cmd/root.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/example/glide.lock
+++ b/example/glide.lock
@@ -1,10 +1,10 @@
-hash: 30c26d18629d3244b09e72950123d006e2359b0729d61d27a773c89ef5f140b9
-updated: 2017-02-28T14:31:25.190137849+01:00
+hash: 4ed1f1353e084fe9e1585e9a1bc2aa06acbedce87c22193e5f15a5c7dd3a9785
+updated: 2017-10-30T10:28:00.895715435+01:00
 imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- name: github.com/Sirupsen/logrus
-  version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
+- name: github.com/sirupsen/logrus
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/cobra
   version: 35136c09d8da66b901337c6e86fd8e88a1a255bd
 - name: github.com/spf13/pflag

--- a/example/glide.yaml
+++ b/example/glide.yaml
@@ -1,5 +1,5 @@
 package: github.com/rebuy-de/golang-template/example
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ^0.11.2
 - package: github.com/spf13/cobra

--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/rebuy-de/golang-template/example/cmd"
 )


### PR DESCRIPTION
From the [docs](https://github.com/Sirupsen/logrus):

> Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.