### PR TITLE
bump rebuy-go-sdk

### DIFF
--- a/example/Gopkg.toml
+++ b/example/Gopkg.toml
@@ -1,3 +1,3 @@
 [[constraint]]
   name = "github.com/rebuy-de/rebuy-go-sdk"
-  version = "1.1.0"
+  version = "1.2.0"

--- a/example/cmd/root.go
+++ b/example/cmd/root.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/rebuy-de/rebuy-go-sdk/cmdutil"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +11,7 @@ type App struct {
 }
 
 func (app *App) Run(cmd *cobra.Command, args []string) {
-	log.Infof("hello %s", app.Name)
+	logrus.Infof("hello %s", app.Name)
 }
 
 func (app *App) Bind(cmd *cobra.Command) {

--- a/example/main.go
+++ b/example/main.go
@@ -1,15 +1,14 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
-
 	"github.com/rebuy-de/golang-template/example/cmd"
 	"github.com/rebuy-de/rebuy-go-sdk/cmdutil"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	defer cmdutil.HandleExit()
 	if err := cmd.NewRootCommand().Execute(); err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 }


### PR DESCRIPTION
* updating SDK to [v1.2.0](https://github.com/rebuy-de/rebuy-go-sdk/releases/tag/v1.2.0)
* import logrus as `logrus` and not as log, since my "IDE" often imports the wrong one and this is anoying (this is negotiable)

@rebuy-de/prp-golang-template @rebuy-de/it-platform 