### PR TITLE
do not change lockfile on vendoring

### DIFF
--- a/example/golang.mk
+++ b/example/golang.mk
@@ -35,7 +35,7 @@ Gopkg.lock: Gopkg.toml
 	touch Gopkg.lock
 
 vendor: Gopkg.lock Gopkg.toml
-	dep ensure
+	dep ensure -vendor-only
 	touch vendor
 
 format:


### PR DESCRIPTION
A user/bot that downloads the vendor, should not need to update the lockfile.

@rebuy-de/prp-golang-template Please review.