### PR TITLE
make dep verbose

### DIFF
--- a/example/golang.mk
+++ b/example/golang.mk
@@ -31,11 +31,11 @@ GOPKGS=$(shell go list ./...)
 default: build
 
 Gopkg.lock: Gopkg.toml
-	dep ensure
+	dep ensure -v
 	touch Gopkg.lock
 
 vendor: Gopkg.lock Gopkg.toml
-	dep ensure -vendor-only
+	dep ensure -v -vendor-only
 	touch vendor
 
 format:


### PR DESCRIPTION
```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
```

See https://travis-ci.org/rebuy-de/kubernetes-deployment/builds/414564585

Failing because of no output seems to be a new trend. Therefore I make `dep` verbose.

@rebuy-de/prp-golang-template Please review.