### PR TITLE
Keep build date international

### DIFF
--- a/example/golang.mk
+++ b/example/golang.mk
@@ -5,7 +5,7 @@ PACKAGE=$(shell GOPATH= go list $(TARGET))
 NAME=$(notdir $(PACKAGE))
 
 BUILD_VERSION=$(shell git describe --always --dirty --tags | tr '-' '.' )
-BUILD_DATE=$(shell date)
+BUILD_DATE=$(shell LC_ALL=C date)
 BUILD_HASH=$(shell git rev-parse HEAD)
 BUILD_MACHINE=$(shell echo $$HOSTNAME)
 BUILD_USER=$(shell whoami)

--- a/example/golang.mk
+++ b/example/golang.mk
@@ -22,7 +22,7 @@ BUILD_FLAGS=-ldflags "\
 	-X '$(BUILD_XDST).BuildEnvironment=$(BUILD_ENVIRONMENT)' \
 "
 
-GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
+GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")
 GOPKGS=$(shell go list ./...)
 
 OUTPUT_FILE=$(NAME)-$(BUILD_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH)$(shell go env GOEXE)


### PR DESCRIPTION
Right now the build date depends on the locale of the machine, leading to varying results:
```
build date:  Fr 3. Mai 15:07:30 CEST 2019
build date:  Fri May  3 15:12:51 CEST 2019
```
With that change we always have the same output format.