### PR TITLE
Add dockerignore file

### DIFF
--- a/example/.dockerignore
+++ b/example/.dockerignore
@@ -1,0 +1,2 @@
+/dist/*
+/vendor/*


### PR DESCRIPTION
We noticed that we have multiple binaries when we build the images locally, because inside the image we copy the contents of the `dist` folder, which can already contain old binaries. In addition this could also make our builds faster.